### PR TITLE
Remove the `rootUrl` export

### DIFF
--- a/app/helpers/root-url.js
+++ b/app/helpers/root-url.js
@@ -1,1 +1,1 @@
-export { default, rootUrl } from 'ember-root-url/helpers/root-url';
+export { default } from 'ember-root-url/helpers/root-url';


### PR DESCRIPTION
The addon file only has a default export.

Embroider was showing a warning about this.